### PR TITLE
날씨, 교통상황에 따른 출발시간 결정 

### DIFF
--- a/app/src/main/java/com/example/timetogo/GpsTracker.java
+++ b/app/src/main/java/com/example/timetogo/GpsTracker.java
@@ -1,0 +1,153 @@
+package com.example.timetogo;
+
+import android.Manifest;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.util.Log;
+import androidx.core.content.ContextCompat;
+
+public class GpsTracker extends Service implements LocationListener {
+    private final Context mContext;
+    Location location;
+    double latitude;
+    double longitude;
+
+    private static final long MIN_DISTANCE_CHANGE_FOR_UPDATES = 10;
+    private static final long MIN_TIME_BW_UPDATES = 1000 * 60 * 1;
+    protected LocationManager locationManager;
+
+
+    public GpsTracker(Context context) {
+        this.mContext = context;
+        getLocation();
+    }
+
+
+    public Location getLocation() {
+        try {
+            locationManager = (LocationManager) mContext.getSystemService(LOCATION_SERVICE);
+
+            boolean isGPSEnabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
+            boolean isNetworkEnabled = locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+
+            if (!isGPSEnabled && !isNetworkEnabled) {
+
+            } else {
+
+                int hasFineLocationPermission = ContextCompat.checkSelfPermission(mContext,
+                        Manifest.permission.ACCESS_FINE_LOCATION);
+                int hasCoarseLocationPermission = ContextCompat.checkSelfPermission(mContext,
+                        Manifest.permission.ACCESS_COARSE_LOCATION);
+
+
+                if (hasFineLocationPermission == PackageManager.PERMISSION_GRANTED &&
+                        hasCoarseLocationPermission == PackageManager.PERMISSION_GRANTED) {
+
+                    ;
+                } else
+                    return null;
+
+
+                if (isNetworkEnabled) {
+
+
+                    locationManager.requestLocationUpdates(LocationManager.NETWORK_PROVIDER, MIN_TIME_BW_UPDATES, MIN_DISTANCE_CHANGE_FOR_UPDATES, this);
+
+                    if (locationManager != null)
+                    {
+                        location = locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
+                        if (location != null)
+                        {
+                            latitude = location.getLatitude();
+                            longitude = location.getLongitude();
+                        }
+                    }
+                }
+
+
+                if (isGPSEnabled)
+                {
+                    if (location == null)
+                    {
+                        locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, MIN_TIME_BW_UPDATES, MIN_DISTANCE_CHANGE_FOR_UPDATES, this);
+                        if (locationManager != null)
+                        {
+                            location = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER);
+                            if (location != null)
+                            {
+                                latitude = location.getLatitude();
+                                longitude = location.getLongitude();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Log.d("@@@", ""+e.toString());
+        }
+
+        return location;
+    }
+
+    public double getLatitude()
+    {
+        if(location != null)
+        {
+            latitude = location.getLatitude();
+        }
+
+        return latitude;
+    }
+
+    public double getLongitude()
+    {
+        if(location != null)
+        {
+            longitude = location.getLongitude();
+        }
+
+        return longitude;
+    }
+
+    @Override
+    public void onLocationChanged(Location location)
+    {
+        if(location != null)
+        {
+            MainActivity.curLat = location.getLatitude();
+            MainActivity.curLng = location.getLongitude();
+        }
+
+    }
+
+    @Override
+    public void onProviderDisabled(String provider)
+    {
+    }
+
+    @Override
+    public void onProviderEnabled(String provider)
+    {
+    }
+
+    @Override
+    public void onStatusChanged(String provider, int status, Bundle extras)
+    {
+    }
+
+    @Override
+    public IBinder onBind(Intent arg0)
+    {
+        return null;
+    }
+
+}

--- a/app/src/main/java/com/example/timetogo/MainActivity.java
+++ b/app/src/main/java/com/example/timetogo/MainActivity.java
@@ -1,14 +1,22 @@
 package com.example.timetogo;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
 import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
 
+import android.Manifest;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.BitmapFactory;
+import android.location.LocationManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.StrictMode;
@@ -74,11 +82,33 @@ public class MainActivity extends AppCompatActivity {
     ArrayAdapter<String> adapter;
     ListView listView;
 
+    static GpsTracker gpsTracker;
+    private static final int GPS_ENABLE_REQUEST_CODE = 2001;
+    private static final int PERMISSIONS_REQUEST_CODE = 100;
+    String[] REQUIRED_PERMISSIONS = {Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION};
+
+    static double curLat;
+    static double curLng;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         StrictMode.enableDefaults();
+
+        //위치 퍼미션
+        if(!checkLocationServicesStatus()) {
+            showDialogForLocationServiceSetting();
+        } else {
+            checkRunTimePermission();
+        }
+
+        GpsTracker gpsTracker = new GpsTracker(MainActivity.this);
+        curLat = gpsTracker.getLatitude();
+        curLng = gpsTracker.getLongitude();
+
+        Toast.makeText(getApplicationContext(),Double.toString(curLat),Toast.LENGTH_SHORT).show();
+        Toast.makeText(getApplicationContext(),Double.toString(curLng),Toast.LENGTH_SHORT).show();
 
         items = new ArrayList<String>();
         items.add("test");
@@ -101,7 +131,7 @@ public class MainActivity extends AppCompatActivity {
         };
         worker.start();
 
-        getWeatherAPI();
+        // getWeatherAPI();
         getTrafficAPI();
 
         result = (TextView) findViewById(R.id.result);
@@ -649,5 +679,97 @@ public class MainActivity extends AppCompatActivity {
         } catch(IOException e) {
             e.printStackTrace();
         }
+    }
+
+    //참고한 사이트: https://webnautes.tistory.com/1315
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        if(requestCode == PERMISSIONS_REQUEST_CODE && grantResults.length == REQUIRED_PERMISSIONS.length) { //요청 코드가 PERMISSONS_REQUEST_CODE이고, 요청한 퍼시면 개수만큼 수신되었다면
+            boolean check_result = true;
+            for(int result : grantResults) {
+                if(result != PackageManager.PERMISSION_GRANTED) {
+                    check_result = false;
+                    break;
+                }
+            }
+
+            if(check_result) {
+            } else {
+                if(ActivityCompat.shouldShowRequestPermissionRationale(this, REQUIRED_PERMISSIONS[0]) || ActivityCompat.shouldShowRequestPermissionRationale(this, REQUIRED_PERMISSIONS[1])) {
+                    Toast.makeText(MainActivity.this, "퍼미션이 거부되었습니다. 앱을 다시 실행하여 퍼미션을 허용해주세요", Toast.LENGTH_LONG).show();
+                    finish();
+                } else {
+                    Toast.makeText(MainActivity.this, "퍼미션이 거부되었습니다. 설정에서 퍼미션을 허용해야 합니다.", Toast.LENGTH_LONG).show();
+                }
+            }
+        }
+    }
+
+    void checkRunTimePermission() {
+        int hasFineLocationPermission = ContextCompat.checkSelfPermission(MainActivity.this,
+                Manifest.permission.ACCESS_FINE_LOCATION);
+        int hasCoarseLocationPermission = ContextCompat.checkSelfPermission(MainActivity.this,
+                Manifest.permission.ACCESS_COARSE_LOCATION);
+
+        if (hasFineLocationPermission == PackageManager.PERMISSION_GRANTED &&
+                hasCoarseLocationPermission == PackageManager.PERMISSION_GRANTED) {
+        } else {
+            if (ActivityCompat.shouldShowRequestPermissionRationale(MainActivity.this, REQUIRED_PERMISSIONS[0])) {
+                Toast.makeText(MainActivity.this, "이 앱을 실행하려면 위치 접근 권한이 필요합니다.", Toast.LENGTH_LONG).show();
+                ActivityCompat.requestPermissions(MainActivity.this, REQUIRED_PERMISSIONS,
+                        PERMISSIONS_REQUEST_CODE);
+            } else {
+                ActivityCompat.requestPermissions(MainActivity.this, REQUIRED_PERMISSIONS,
+                        PERMISSIONS_REQUEST_CODE);
+            }
+        }
+    }
+
+    //여기부터는 GPS 활성화를 위한 메소드들
+    private void showDialogForLocationServiceSetting() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(MainActivity.this);
+        builder.setTitle("위치 서비스 비활성화");
+        builder.setMessage("앱을 사용하기 위해서는 위치 서비스가 필요합니다.\n"
+                + "위치 설정을 수정하실래요?");
+        builder.setCancelable(true);
+        builder.setPositiveButton("설정", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int id) {
+                Intent callGPSSettingIntent
+                        = new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS);
+                startActivityForResult(callGPSSettingIntent, GPS_ENABLE_REQUEST_CODE);
+            }
+        });
+        builder.setNegativeButton("취소", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int id) {
+                dialog.cancel();
+            }
+        });
+        builder.create().show();
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        switch (requestCode) {
+            case GPS_ENABLE_REQUEST_CODE:
+                if (checkLocationServicesStatus()) {
+                    if (checkLocationServicesStatus()) {
+
+                        Log.d("@@@", "onActivityResult : GPS 활성화 되있음");
+                        checkRunTimePermission();
+                        return;
+                    }
+                }
+                break;
+        }
+    }
+
+    public boolean checkLocationServicesStatus() {
+        LocationManager locationManager = (LocationManager) getSystemService(LOCATION_SERVICE);
+        return locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)
+                || locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
     }
 }

--- a/app/src/main/java/com/example/timetogo/MainActivity.java
+++ b/app/src/main/java/com/example/timetogo/MainActivity.java
@@ -121,7 +121,7 @@ public class MainActivity extends AppCompatActivity {
 
         Traffic traffic = new Traffic();
         traffic.getTrafficAPI();
-        Toast.makeText(getApplicationContext(),traffic.speed,Toast.LENGTH_SHORT).show();
+        traffic.categorize();
 
         result = (TextView) findViewById(R.id.result);
 

--- a/app/src/main/java/com/example/timetogo/MainActivity.java
+++ b/app/src/main/java/com/example/timetogo/MainActivity.java
@@ -115,13 +115,9 @@ public class MainActivity extends AppCompatActivity {
         };
         worker.start();
 
-        Weather weather = new Weather();
-        weather.getWeatherAPI(curLat, curLng);
-        weather.categorize();
-
-        Traffic traffic = new Traffic();
-        traffic.getTrafficAPI();
-        traffic.categorize();
+        Time time = new Time(curLat, curLng);
+        time.determineTime();
+        Toast.makeText(getApplicationContext(),Integer.toString(time.early),Toast.LENGTH_SHORT).show();
 
         result = (TextView) findViewById(R.id.result);
 

--- a/app/src/main/java/com/example/timetogo/MainActivity.java
+++ b/app/src/main/java/com/example/timetogo/MainActivity.java
@@ -50,7 +50,7 @@ public class MainActivity extends AppCompatActivity {
     static int min;
     static String strweek = null;
     String data;
-    static String weatherValue = null;
+
     public ArrayList<String> busRouteList; //노선Id들의 리스트
     public ArrayList<String> stationList; //정류소Id들의 리스트
     public ArrayList<String> stationNmList; //정류소 이름들의 리스트
@@ -117,7 +117,7 @@ public class MainActivity extends AppCompatActivity {
 
         Weather weather = new Weather();
         weather.getWeatherAPI(curLat, curLng);
-        Toast.makeText(getApplicationContext(), weatherValue, Toast.LENGTH_SHORT).show();
+        Toast.makeText(getApplicationContext(), weather.weatherNumber, Toast.LENGTH_SHORT).show();
 
         getTrafficAPI();
 

--- a/app/src/main/java/com/example/timetogo/MainActivity.java
+++ b/app/src/main/java/com/example/timetogo/MainActivity.java
@@ -50,7 +50,7 @@ public class MainActivity extends AppCompatActivity {
     static int min;
     static String strweek = null;
     String data;
-    static String weather = null;
+    static String weatherValue = null;
     public ArrayList<String> busRouteList; //노선Id들의 리스트
     public ArrayList<String> stationList; //정류소Id들의 리스트
     public ArrayList<String> stationNmList; //정류소 이름들의 리스트
@@ -115,7 +115,10 @@ public class MainActivity extends AppCompatActivity {
         };
         worker.start();
 
-        getWeatherAPI();
+        Weather weather = new Weather();
+        weather.getWeatherAPI(curLat, curLng);
+        Toast.makeText(getApplicationContext(), weatherValue, Toast.LENGTH_SHORT).show();
+
         getTrafficAPI();
 
         result = (TextView) findViewById(R.id.result);
@@ -295,37 +298,6 @@ public class MainActivity extends AppCompatActivity {
 
         items.add(text);
         adapter.notifyDataSetChanged();
-    }
-
-    public void getWeatherAPI() {
-        TextView status1 = (TextView) findViewById(R.id.result); //파싱된 결과확인!
-
-        try {
-            URL url = new URL("http://api.openweathermap.org/data/2.5/weather?lat="+curLat+"&lon="+curLng+"&appid=214ca5ff55f7bc7e5e085dafb21c0789&mode=xml&lang=kr&units=metric");
-
-            XmlPullParserFactory parserCreator = XmlPullParserFactory.newInstance();
-            XmlPullParser parser = parserCreator.newPullParser();
-
-            parser.setInput(url.openStream(), null);
-
-            int parserEvent = parser.getEventType();
-            System.out.println("파싱 시작합니다");
-
-            while(parserEvent != XmlPullParser.END_DOCUMENT) {
-                switch(parserEvent) {
-                    case XmlPullParser.START_TAG:
-                        if(parser.getName().equals("weather")) {
-                            weather = parser.getAttributeValue(null, "value");
-                            Toast.makeText(this, weather, Toast.LENGTH_SHORT).show();
-                        }
-                        break;
-                }
-                parserEvent = parser.next();
-            }
-        } catch (Exception e) {
-            status1.setText("에러가..났습니다...");
-            e.printStackTrace();
-        }
     }
 
     public void getTrafficAPI() {

--- a/app/src/main/java/com/example/timetogo/MainActivity.java
+++ b/app/src/main/java/com/example/timetogo/MainActivity.java
@@ -117,9 +117,11 @@ public class MainActivity extends AppCompatActivity {
 
         Weather weather = new Weather();
         weather.getWeatherAPI(curLat, curLng);
-        Toast.makeText(getApplicationContext(), weather.weatherNumber, Toast.LENGTH_SHORT).show();
+        weather.categorize();
 
-        getTrafficAPI();
+        Traffic traffic = new Traffic();
+        traffic.getTrafficAPI();
+        Toast.makeText(getApplicationContext(),traffic.speed,Toast.LENGTH_SHORT).show();
 
         result = (TextView) findViewById(R.id.result);
 
@@ -298,52 +300,6 @@ public class MainActivity extends AppCompatActivity {
 
         items.add(text);
         adapter.notifyDataSetChanged();
-    }
-
-    public void getTrafficAPI() {
-
-        boolean in_prcs_spd = false;
-
-        String prcs_spd = null;
-
-        try {
-            URL url = new URL("http://openapi.seoul.go.kr:8088/737a6d6e6968796f34375474525268/xml/TrafficInfo/1/3/1220003800");
-            XmlPullParserFactory parserCreator = XmlPullParserFactory.newInstance();
-            XmlPullParser parser = parserCreator.newPullParser();
-
-            parser.setInput(url.openStream(), null);
-
-            int parserEvent = parser.getEventType();
-            System.out.println("파싱 시작합니다");
-
-            while(parserEvent != XmlPullParser.END_DOCUMENT) {
-                switch(parserEvent) {
-                    case XmlPullParser.START_TAG:
-                        if(parser.getName().equals("prcs_spd")) {
-                            in_prcs_spd = true;
-                        }
-                        break;
-                    case XmlPullParser.TEXT:
-                        if(in_prcs_spd) {
-                            prcs_spd = parser.getText();
-
-                            in_prcs_spd = false;
-                        }
-                        break;
-                    case XmlPullParser.END_TAG:
-                        if(parser.getName().equals("row")) {
-                            Toast.makeText(this, prcs_spd, Toast.LENGTH_LONG).show();
-                            break;
-                        }
-                        break;
-                }
-                parserEvent = parser.next();
-            }
-
-        } catch(Exception e) {
-            //error
-        }
-
     }
 
     public void NotificationSomethings() {

--- a/app/src/main/java/com/example/timetogo/Time.java
+++ b/app/src/main/java/com/example/timetogo/Time.java
@@ -1,0 +1,52 @@
+package com.example.timetogo;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class Time extends AppCompatActivity {
+
+    double curLat;
+    double curLng;
+
+    boolean rainSnow;
+    boolean sunny;
+    boolean green;
+    boolean yellow;
+    boolean red;
+
+    public int early = 0;
+
+    public Time(double curLat, double curLng) {
+        this.curLat = curLat;
+        this.curLng = curLng;
+    }
+
+    public void determineTime() {
+        Weather weather = new Weather();
+        weather.getWeatherAPI(this.curLat, this.curLng);
+        weather.categorize();
+
+        Traffic traffic = new Traffic();
+        traffic.getTrafficAPI();
+        traffic.categorize();
+
+        this.rainSnow = weather.rainSnow;
+        this.sunny = weather.sunny;
+        this.green = traffic.green;
+        this.yellow = traffic.yellow;
+        this.red = traffic.red;
+
+        if (sunny && green) {
+            early = 0;
+        } else if (sunny && yellow) {
+            early = 1;
+        } else if (sunny && red) {
+            early = 2;
+        } else if (rainSnow && green) {
+            early = 1;
+        } else if (rainSnow && yellow) {
+            early = 2;
+        } else if (rainSnow && red) {
+            early = 3;
+        }
+    }
+}

--- a/app/src/main/java/com/example/timetogo/Traffic.java
+++ b/app/src/main/java/com/example/timetogo/Traffic.java
@@ -1,0 +1,51 @@
+package com.example.timetogo;
+
+import androidx.appcompat.app.AppCompatActivity;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserFactory;
+import java.net.URL;
+
+public class Traffic extends AppCompatActivity {
+
+    static String speed = null;
+
+    public void getTrafficAPI() {
+        boolean in_prcs_spd = false;
+        String prcs_spd = null;
+
+        try {
+            URL url = new URL("http://openapi.seoul.go.kr:8088/737a6d6e6968796f34375474525268/xml/TrafficInfo/1/3/1220003800");
+            XmlPullParserFactory parserCreator = XmlPullParserFactory.newInstance();
+            XmlPullParser parser = parserCreator.newPullParser();
+
+            parser.setInput(url.openStream(), null);
+
+            int parserEvent = parser.getEventType();
+
+            while(parserEvent != XmlPullParser.END_DOCUMENT) {
+                switch(parserEvent) {
+                    case XmlPullParser.START_TAG:
+                        if(parser.getName().equals("prcs_spd")) {
+                            in_prcs_spd = true;
+                        }
+                        break;
+                    case XmlPullParser.TEXT:
+                        if(in_prcs_spd) {
+                            prcs_spd = parser.getText();
+                            in_prcs_spd = false;
+                        }
+                        break;
+                    case XmlPullParser.END_TAG:
+                        if(parser.getName().equals("row")) {
+                            speed = prcs_spd;
+                            break;
+                        }
+                        break;
+                }
+                parserEvent = parser.next();
+            }
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/app/src/main/java/com/example/timetogo/Traffic.java
+++ b/app/src/main/java/com/example/timetogo/Traffic.java
@@ -7,7 +7,11 @@ import java.net.URL;
 
 public class Traffic extends AppCompatActivity {
 
-    static String speed = null;
+    public String speed = null;
+    public int intSpeed = 0;
+    public boolean green = false;
+    public boolean yellow = false;
+    public boolean red = false;
 
     public void getTrafficAPI() {
         boolean in_prcs_spd = false;
@@ -46,6 +50,17 @@ public class Traffic extends AppCompatActivity {
             }
         } catch(Exception e) {
             e.printStackTrace();
+        }
+    }
+
+    public void categorize() {
+        intSpeed = Integer.parseInt(speed);
+        if (intSpeed < 40) {
+            red = true;
+        } else if (intSpeed <= 80) {
+            yellow = true;
+        } else {
+            green = true;
         }
     }
 }

--- a/app/src/main/java/com/example/timetogo/Weather.java
+++ b/app/src/main/java/com/example/timetogo/Weather.java
@@ -1,0 +1,38 @@
+package com.example.timetogo;
+
+import androidx.appcompat.app.AppCompatActivity;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserFactory;
+import java.net.URL;
+
+import static com.example.timetogo.MainActivity.weatherValue;
+
+public class Weather extends AppCompatActivity {
+
+    public void getWeatherAPI(double curLat, double curLng) {
+        try {
+            URL url = new URL("http://api.openweathermap.org/data/2.5/weather?lat="+curLat+"&lon="+curLng+"&appid=214ca5ff55f7bc7e5e085dafb21c0789&mode=xml&lang=kr&units=metric");
+
+            XmlPullParserFactory parserCreator = XmlPullParserFactory.newInstance();
+            XmlPullParser parser = parserCreator.newPullParser();
+
+            parser.setInput(url.openStream(), null);
+
+            int parserEvent = parser.getEventType();
+            System.out.println("파싱 시작합니다");
+
+            while(parserEvent != XmlPullParser.END_DOCUMENT) {
+                switch(parserEvent) {
+                    case XmlPullParser.START_TAG:
+                        if(parser.getName().equals("weather")) {
+                            weatherValue = parser.getAttributeValue(null, "value");
+                        }
+                        break;
+                }
+                parserEvent = parser.next();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/app/src/main/java/com/example/timetogo/Weather.java
+++ b/app/src/main/java/com/example/timetogo/Weather.java
@@ -5,9 +5,12 @@ import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserFactory;
 import java.net.URL;
 
-import static com.example.timetogo.MainActivity.weatherValue;
-
 public class Weather extends AppCompatActivity {
+
+    public String weatherNumber = null;
+    public int intNumber = 0;
+    public boolean rainSnow = false;
+    public boolean sunny = false;
 
     public void getWeatherAPI(double curLat, double curLng) {
         try {
@@ -19,13 +22,12 @@ public class Weather extends AppCompatActivity {
             parser.setInput(url.openStream(), null);
 
             int parserEvent = parser.getEventType();
-            System.out.println("파싱 시작합니다");
 
             while(parserEvent != XmlPullParser.END_DOCUMENT) {
                 switch(parserEvent) {
                     case XmlPullParser.START_TAG:
                         if(parser.getName().equals("weather")) {
-                            weatherValue = parser.getAttributeValue(null, "value");
+                            weatherNumber = parser.getAttributeValue(null, "number");
                         }
                         break;
                 }
@@ -33,6 +35,23 @@ public class Weather extends AppCompatActivity {
             }
         } catch (Exception e) {
             e.printStackTrace();
+        }
+    }
+
+    public void categorize() {
+        intNumber = Integer.parseInt(weatherNumber);
+        if (intNumber < 300) { //thunderstorm
+            rainSnow = true;
+        } else if (intNumber < 500) { //drizzle
+            rainSnow = true;
+        } else if (intNumber < 600) { //rain
+            rainSnow = true;
+        } else if (intNumber < 700) { //snow
+            rainSnow = true;
+        } else if (intNumber < 800) { //atmosphere
+            sunny = true;
+        } else if (intNumber < 900) { //clear, clouds
+            sunny = true;
         }
     }
 }


### PR DESCRIPTION
## 현 상태
### 날씨
변경 전:
- [기상청 날씨 API](https://www.weather.go.kr/weather/lifenindustry/sevice_rss.jsp) 사용 
- 중기예보를 사용하여 현재 위치의 현재 날씨를 받아오지 못함
- 동네예보 > 시간별예보를 사용할까 고민해봤지만... 현재 날씨가 아닌 3시, 5시, 이런식으로 특정 시간에만 날씨가 업데이트 되기 때문에 다른 API를 사용하기로 결정

변경 후:
- [OpenWeather API](https://openweathermap.org/api) 사용
- 현재 위도와 경도를 넘겨주면 해당 위치의 현재 날씨를 받아올 수 있다 (훨씬 더 정확해짐!!😃)
- 아래와 같이 표시되는데, 여기서 weather태그 안의 number를 사용해서 날씨 카테고리를 분류
- 참고: #4 
![xml](https://user-images.githubusercontent.com/31886880/76406384-fac64f00-63cc-11ea-97e0-503b0f9648e8.PNG)

### 교통상황
변경 전: 
- [서울시 실시간 도로 소통 정보 API](http://data.seoul.go.kr/dataList/OA-13291/A/1/datasetView.do) 받아오기

변경 후:
- 교통상황 카테고리 분류
- 참고: #5 

### 출발시간 결정
- 날씨와 교통상황 카테고리 분류된것을 조합하여 출발시간 결정
- 참고: #7 

## 후속 작업
- 다른 교통소통 API를 사용하기