### PR TITLE
교통상황 받아오기 

### DIFF
--- a/app/src/main/java/com/example/timetogo/Bus.java
+++ b/app/src/main/java/com/example/timetogo/Bus.java
@@ -1,0 +1,205 @@
+package com.example.timetogo;
+
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserFactory;
+import java.net.URL;
+import java.util.ArrayList;
+
+public class Bus {
+
+    public ArrayList<String> busRouteList; //노선Id들의 리스트
+    public ArrayList<String> stationList; //정류소Id들의 리스트
+    public ArrayList<String> stationNmList; //정류소 이름들의 리스트
+    public ArrayList<String> stationNoList; //정류소 번호들의 리스트
+    public ArrayList<String> seqList; //정류소 순번들의 리스트
+    public String text = "";
+
+    public void showBusList(String bus, String station) {
+        busRouteList = new ArrayList<String>();
+        stationList = new ArrayList<String>();
+        stationNmList = new ArrayList<String>();
+        stationNoList = new ArrayList<String>();
+        seqList = new ArrayList<String>();
+        text = "";
+
+        getBusRouteList(bus);
+        getStationsByRouteList(busRouteList.get(0));
+        for (int i = 0; i < stationNoList.size(); i++) {
+            if (stationNoList.get(i).equals(station)) {
+                getBusAPI(stationList.get(i), busRouteList.get(0), seqList.get(i));
+            }
+        }
+
+        MainActivity.items.add(text);
+        MainActivity.adapter.notifyDataSetChanged();
+    }
+
+    public void getBusAPI(String stId, String busRouteId, String ord) { //getLowArrInfoByStIdList
+
+        boolean in_rtNm = false, in_arrmsg1 = false, in_arrmsg2 = false;
+
+        String rtNm = null, arrmsg1 = null, arrmsg2 = null;
+
+        try {
+            URL url = new URL("http://ws.bus.go.kr/api/rest/arrive/getLowArrInfoByRoute?serviceKey=4Sc5MPbhBeWyQLVQ1JM9AqGWarV75Qk9hG%2FLuWVNl7%2B4hyHn8nP0mGrsxqDJHcgRdrSYT7sjblUpHpqjDcXdbw%3D%3D&stId=" + stId + "&busRouteId=" + busRouteId + "&ord=" + ord);
+            XmlPullParserFactory parserCreator = XmlPullParserFactory.newInstance();
+            XmlPullParser parser = parserCreator.newPullParser();
+
+            parser.setInput(url.openStream(), null);
+
+            int parserEvent = parser.getEventType();
+            System.out.println("파싱 시작합니다");
+
+            while(parserEvent != XmlPullParser.END_DOCUMENT) {
+                switch(parserEvent) {
+                    case XmlPullParser.START_TAG:
+                        if(parser.getName().equals("rtNm")) {
+                            in_rtNm = true;
+                        }
+                        if(parser.getName().equals("arrmsg1")) {
+                            in_arrmsg1 = true;
+                        }
+                        if(parser.getName().equals("arrmsg2")) {
+                            in_arrmsg2 = true;
+                        }
+                        break;
+                    case XmlPullParser.TEXT:
+                        if(in_rtNm) {
+                            rtNm = parser.getText();
+                            in_rtNm = false;
+                        }
+                        if(in_arrmsg1) {
+                            arrmsg1 = parser.getText();
+                            in_arrmsg1 = false;
+                        }
+                        if(in_arrmsg2) {
+                            arrmsg2 = parser.getText();
+                            in_arrmsg2 = false;
+                        }
+                        break;
+                    case XmlPullParser.END_TAG:
+                        if(parser.getName().equals("itemList")) {
+                            text = "버스번호: " + rtNm + "첫번째 전: " + arrmsg1 + "두번째 전" + arrmsg2+"\n";
+                        }
+                        break;
+                }
+                parserEvent = parser.next();
+            }
+
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void getStationsByRouteList(String busRouteId) { //busRouteId를 넣으면 stationId를 리턴한다.
+
+        boolean in_station = false, in_stationNm = false, in_stationNo = false, in_seq = false;
+
+        String station = null, stationNm = null, stationNo = null, seq = null;
+
+        try {
+            URL url = new URL("http://ws.bus.go.kr/api/rest/busRouteInfo/getStaionByRoute?serviceKey=4Sc5MPbhBeWyQLVQ1JM9AqGWarV75Qk9hG%2FLuWVNl7%2B4hyHn8nP0mGrsxqDJHcgRdrSYT7sjblUpHpqjDcXdbw%3D%3D&busRouteId="+busRouteId);
+            XmlPullParserFactory parserCreator = XmlPullParserFactory.newInstance();
+            XmlPullParser parser = parserCreator.newPullParser();
+
+            parser.setInput(url.openStream(), null);
+
+            int parserEvent = parser.getEventType();
+            System.out.println("파싱 시작합니다");
+
+            while(parserEvent != XmlPullParser.END_DOCUMENT) {
+                switch(parserEvent) {
+                    case XmlPullParser.START_TAG:
+                        if(parser.getName().equals("station")) {
+                            in_station = true;
+                        }
+                        if(parser.getName().equals("stationNm")) {
+                            in_stationNm = true;
+                        }
+                        if(parser.getName().equals("stationNo")) {
+                            in_stationNo = true;
+                        }
+                        if(parser.getName().equals("seq")) {
+                            in_seq = true;
+                        }
+                        break;
+                    case XmlPullParser.TEXT:
+                        if(in_station) {
+                            station = parser.getText();
+                            in_station = false;
+                        }
+                        if(in_stationNm) {
+                            stationNm = parser.getText();
+                            in_stationNm = false;
+                        }
+                        if(in_stationNo) {
+                            stationNo = parser.getText();
+                            in_stationNo = false;
+                        }
+                        if(in_seq) {
+                            seq = parser.getText();
+                            in_seq = false;
+                        }
+                        break;
+                    case XmlPullParser.END_TAG:
+                        if(parser.getName().equals("itemList")) {
+                            stationList.add(station);
+                            stationNmList.add(stationNm);
+                            stationNoList.add(stationNo);
+                            seqList.add(seq);
+                        }
+                        break;
+                }
+                parserEvent = parser.next();
+            }
+
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void getBusRouteList(String busRouteNm) { //버스 번호를 입력하면 busRouteId를 리턴한다
+
+        boolean in_busRouteId = false;
+
+        String busRouteId = null;
+
+        try {
+            URL url = new URL("http://ws.bus.go.kr/api/rest/busRouteInfo/getBusRouteList?serviceKey=4Sc5MPbhBeWyQLVQ1JM9AqGWarV75Qk9hG%2FLuWVNl7%2B4hyHn8nP0mGrsxqDJHcgRdrSYT7sjblUpHpqjDcXdbw%3D%3D&strSrch="+busRouteNm);
+            XmlPullParserFactory parserCreator = XmlPullParserFactory.newInstance();
+            XmlPullParser parser = parserCreator.newPullParser();
+
+            parser.setInput(url.openStream(), null);
+
+            int parserEvent = parser.getEventType();
+            System.out.println("파싱 시작합니다");
+
+            while(parserEvent != XmlPullParser.END_DOCUMENT) {
+                switch(parserEvent) {
+                    case XmlPullParser.START_TAG:
+                        if(parser.getName().equals("busRouteId")) {
+                            in_busRouteId = true;
+                        }
+                        break;
+                    case XmlPullParser.TEXT:
+                        if(in_busRouteId) {
+                            busRouteId = parser.getText();
+
+                            in_busRouteId = false;
+                        }
+                        break;
+                    case XmlPullParser.END_TAG:
+                        if(parser.getName().equals("itemList")) {
+                            busRouteList.add(busRouteId);
+                            break;
+                        }
+                        break;
+                }
+                parserEvent = parser.next();
+            }
+
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/app/src/main/java/com/example/timetogo/Bus.java
+++ b/app/src/main/java/com/example/timetogo/Bus.java
@@ -122,7 +122,7 @@ public class Bus {
                         break;
                     case XmlPullParser.END_TAG:
                         if(parser.getName().equals("itemList")) {
-                            text = "버스번호: " + rtNm + "첫번째 전: " + arrmsg1 + "두번째 전" + arrmsg2+"\n";
+                            text = "버스번호: " + rtNm + "\n" + "첫번째 전: " + arrmsg1 + "\n" + "두번째 전" + arrmsg2+"\n";
                         }
                         break;
                 }

--- a/app/src/main/java/com/example/timetogo/MainActivity.java
+++ b/app/src/main/java/com/example/timetogo/MainActivity.java
@@ -142,6 +142,12 @@ public class MainActivity extends AppCompatActivity {
                         }
                         if(nWeek==3){
                             strweek="화요일";
+                            alarmTime(22,2,1);
+                            alarmTime(22,3,2);
+                            alarmTime(22,4,3);
+                            alarmTime(22,5,4);
+                            alarmTime(22,6,5);
+                            alarmTime(22,7,6);
                         }
                         if(nWeek==4){
                             strweek="수요일";
@@ -270,12 +276,14 @@ public class MainActivity extends AppCompatActivity {
 
                                 bus.showBusList(bus1, station1, destStn);
                                 //showBusList(bus1, station1);
-                                NotificationSomethings();
+                                NotificationSomethings(bus.text);
 
                                 Time time = new Time(curLat, curLng);
                                 time.determineTime();
-                                Toast.makeText(getApplicationContext(),Integer.toString(bus.averageSpd),Toast.LENGTH_SHORT).show();
-                                Toast.makeText(getApplicationContext(),Integer.toString(time.early),Toast.LENGTH_SHORT).show();
+                                items.add(time.text);
+                                //NotificationSomethings(Integer.toString(time.early));
+                                // Toast.makeText(getApplicationContext(),Integer.toString(bus.averageSpd),Toast.LENGTH_SHORT).show();
+                                // Toast.makeText(getApplicationContext(),Integer.toString(time.early),Toast.LENGTH_SHORT).show();
 
                             }
                          });
@@ -289,11 +297,8 @@ public class MainActivity extends AppCompatActivity {
         worker.start();
     }
 
-    public void NotificationSomethings() {
-
-
+    public void NotificationSomethings(String contentText) {
         NotificationManager notificationManager = (NotificationManager)getSystemService(Context.NOTIFICATION_SERVICE);
-
         Intent notificationIntent = new Intent(this, ResultActivity.class);
         notificationIntent.putExtra("notificationId", count); //전달할 값
         notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK) ;
@@ -304,7 +309,7 @@ public class MainActivity extends AppCompatActivity {
                 .setContentTitle("Time to go!!!").setWhen(System.currentTimeMillis())
 
                 //.setContentText("상태바 드래그시 보이는 서브타이틀").setVibrate(new long[]{40,300})
-                .setContentText(bus.text).setVibrate(new long[]{40,300})
+                .setContentText(contentText).setVibrate(new long[]{40,300})
 
                 //출처: https://androphil.tistory.com/368?category=423967 [소림사의 홍반장!]
                 // 더 많은 내용이라서 일부만 보여줘야 하는 경우 아래 주석을 제거하면 setContentText에 있는 문자열 대신 아래 문자열을 보여줌

--- a/app/src/main/java/com/example/timetogo/MainActivity.java
+++ b/app/src/main/java/com/example/timetogo/MainActivity.java
@@ -56,6 +56,7 @@ public class MainActivity extends AppCompatActivity {
     String[] data_split;
     static String bus1;
     static String station1;
+    static String destStn;
 
     static ArrayList<String> items;
     static ArrayAdapter<String> adapter;
@@ -111,9 +112,9 @@ public class MainActivity extends AppCompatActivity {
         };
         worker.start();
 
-        Time time = new Time(curLat, curLng);
-        time.determineTime();
-        Toast.makeText(getApplicationContext(),Integer.toString(time.early),Toast.LENGTH_SHORT).show();
+        //Time time = new Time(curLat, curLng);
+        //time.determineTime();
+        //Toast.makeText(getApplicationContext(),Integer.toString(time.early),Toast.LENGTH_SHORT).show();
 
         result = (TextView) findViewById(R.id.result);
 
@@ -158,12 +159,12 @@ public class MainActivity extends AppCompatActivity {
                         }
                         if(nWeek==6){
                             strweek="금요일";
-                            alarmTime(18,25,1);
-                            alarmTime(18,26,2);
-                            alarmTime(18,27,3);
-                            alarmTime(18,28,4);
-                            alarmTime(18,29,5);
-                            alarmTime(18,30, 6);
+                            alarmTime(21,43,1);
+                            alarmTime(21,44,2);
+                            alarmTime(21,45,3);
+                            alarmTime(21,46,4);
+                            alarmTime(21,47,5);
+                            alarmTime(21,48, 6);
                         }
                         if(nWeek==7){
                             strweek="토요일";
@@ -260,9 +261,21 @@ public class MainActivity extends AppCompatActivity {
                                     station1 = data_split[0];
                                 }
 
-                                bus.showBusList(bus1, station1);
+                                if(data_split[2].contains("-")) {
+                                    String[] temp = data_split[2].split("-");
+                                    destStn = temp[0] + temp[1];
+                                } else {
+                                    destStn = data_split[2];
+                                }
+
+                                bus.showBusList(bus1, station1, destStn);
                                 //showBusList(bus1, station1);
                                 NotificationSomethings();
+
+                                Time time = new Time(curLat, curLng);
+                                time.determineTime();
+                                Toast.makeText(getApplicationContext(),Integer.toString(bus.averageSpd),Toast.LENGTH_SHORT).show();
+                                Toast.makeText(getApplicationContext(),Integer.toString(time.early),Toast.LENGTH_SHORT).show();
 
                             }
                          });

--- a/app/src/main/java/com/example/timetogo/MainActivity.java
+++ b/app/src/main/java/com/example/timetogo/MainActivity.java
@@ -142,10 +142,10 @@ public class MainActivity extends AppCompatActivity {
                         }
                         if(nWeek==3){
                             strweek="화요일";
-                            alarmTime(22,2,1);
-                            alarmTime(22,3,2);
-                            alarmTime(22,4,3);
-                            alarmTime(22,5,4);
+                            alarmTime(22,11,1);
+                            alarmTime(22,12,2);
+                            alarmTime(22,13,3);
+                            alarmTime(22,14,4);
                             alarmTime(22,6,5);
                             alarmTime(22,7,6);
                         }

--- a/app/src/main/java/com/example/timetogo/Time.java
+++ b/app/src/main/java/com/example/timetogo/Time.java
@@ -26,7 +26,6 @@ public class Time extends AppCompatActivity {
         weather.categorize();
 
         Traffic traffic = new Traffic();
-        traffic.getTrafficAPI();
         traffic.categorize();
 
         this.rainSnow = weather.rainSnow;

--- a/app/src/main/java/com/example/timetogo/Time.java
+++ b/app/src/main/java/com/example/timetogo/Time.java
@@ -15,6 +15,8 @@ public class Time extends AppCompatActivity {
 
     public int early = 0;
 
+    public String text = "";
+
     public Time(double curLat, double curLng) {
         this.curLat = curLat;
         this.curLng = curLng;
@@ -36,16 +38,34 @@ public class Time extends AppCompatActivity {
 
         if (sunny && green) {
             early = 0;
+            text = "날씨: 맑음\n" +
+                    "교통상황: 원활\n" +
+                    "오늘은 평소와 같은 시간에 출발해주세요";
         } else if (sunny && yellow) {
             early = 1;
+            text = "날씨: 맑음\n" +
+                    "교통상황: 서행\n" +
+                    "교통상황이 다소 좋지 않으니 첫번째 전 버스를 사용해주세요.";
         } else if (sunny && red) {
             early = 2;
+            text = "날씨: 맑음\n" +
+                    "교통상황: 정체\n" +
+                    "교통상황이 많이 좋지 않으니 두번째 전 버스를 사용해주세요.";
         } else if (rainSnow && green) {
             early = 1;
+            text = "날씨: 비/눈\n" +
+                    "교통상황: 원활\n" +
+                    "날씨로 인해 밀릴 수 있으니 첫번째 전 버스를 사용해주세요.";
         } else if (rainSnow && yellow) {
             early = 2;
+            text = "날씨: 비/눈\n" +
+                    "교통상황: 서행\n" +
+                    "날씨와 교통상황으로 인해 밀릴 수 있으니 두번째 전 버스를 사용해주세요.";
         } else if (rainSnow && red) {
             early = 3;
+            text = "날씨: 비/눈\n" +
+                    "교통상황: 정체\n" +
+                    "날씨와 교통상황으로 인해 많이 밀릴 수 있으니 세번째 버스를 사용해주세요.";
         }
     }
 }

--- a/app/src/main/java/com/example/timetogo/Traffic.java
+++ b/app/src/main/java/com/example/timetogo/Traffic.java
@@ -7,57 +7,17 @@ import java.net.URL;
 
 public class Traffic extends AppCompatActivity {
 
-    public String speed = null;
-    public int intSpeed = 0;
+    public int speed = 0;
     public boolean green = false;
     public boolean yellow = false;
     public boolean red = false;
 
-    public void getTrafficAPI() {
-        boolean in_prcs_spd = false;
-        String prcs_spd = null;
-
-        try {
-            URL url = new URL("http://openapi.seoul.go.kr:8088/737a6d6e6968796f34375474525268/xml/TrafficInfo/1/3/1220003800");
-            XmlPullParserFactory parserCreator = XmlPullParserFactory.newInstance();
-            XmlPullParser parser = parserCreator.newPullParser();
-
-            parser.setInput(url.openStream(), null);
-
-            int parserEvent = parser.getEventType();
-
-            while(parserEvent != XmlPullParser.END_DOCUMENT) {
-                switch(parserEvent) {
-                    case XmlPullParser.START_TAG:
-                        if(parser.getName().equals("prcs_spd")) {
-                            in_prcs_spd = true;
-                        }
-                        break;
-                    case XmlPullParser.TEXT:
-                        if(in_prcs_spd) {
-                            prcs_spd = parser.getText();
-                            in_prcs_spd = false;
-                        }
-                        break;
-                    case XmlPullParser.END_TAG:
-                        if(parser.getName().equals("row")) {
-                            speed = prcs_spd;
-                            break;
-                        }
-                        break;
-                }
-                parserEvent = parser.next();
-            }
-        } catch(Exception e) {
-            e.printStackTrace();
-        }
-    }
-
     public void categorize() {
-        intSpeed = Integer.parseInt(speed);
-        if (intSpeed < 40) {
+        speed = Bus.averageSpd;
+
+        if (speed < 40) {
             red = true;
-        } else if (intSpeed <= 80) {
+        } else if (speed <= 80) {
             yellow = true;
         } else {
             green = true;


### PR DESCRIPTION
## 현 상태
참고: #10 

변경 전: 
- 서울시 실시간 도로 소통 정보 API 사용
- 이 방법에 아래 링크와 같은 문제점들이 있다고 판단하여 다른 방법을 사용하기로 했다
- 참고: #6 

변경 후: 
- 버스 노선정보 API를 활용하여 버스의 속도를 알아내었다
- 각 구간에 대한 버스 속도가 나오는데, 만약 A 정류장부터 B정류장까지의 교통상황을 알고 싶은 경우에는 정류장 사이 모든 구간의 버스 속도를 다 더해서 구간 개수로 나누어 평균값을 알아내었다
- 교통상황 카테고리 분류는 이전과 동일하다 
- 날씨와 교통상황에 따른 메시지 띄우기 

## 후속작업
- 걸음 수에 따른 알림 제공 
